### PR TITLE
feat: enable metrics endpoint scraping

### DIFF
--- a/templates/openmcp/templates/resources/deployment.yaml
+++ b/templates/openmcp/templates/resources/deployment.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
         app: openmcp-operator
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: openmcp-operator
       initContainers:
@@ -67,6 +71,8 @@ spec:
             - --environment=<environment>
             - --config=/etc/secret/openmcp-operator-config/config
             - --provider-name=managedcontrolplane
+            - --metrics-bind-address=:8080
+            - --metrics-secure=false
           env:
             - name: POD_NAME
               valueFrom:
@@ -97,6 +103,10 @@ spec:
               memory: 1024Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+          ports:
+            - name: metrics-http
+              containerPort: 8080
+              protocol: TCP
           volumeMounts:
             - mountPath: /etc/secret/openmcp-operator-config
               name: openmcp-operator-config


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables the controller-runtime metrics endpoint scraping for the openmcp-operator deployment

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Enable controller-runtime metrics endpoint scraping
```
